### PR TITLE
Minor Updates That Helped Me At Least 😄 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+# This is a basic workflow to help you get started with Actions
+name: Release
+on:
+  push:
+    tags:
+      - '**'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Get the version
+        id: get_tag
+        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+      - name: Run build script
+        run: |
+          echo Building Release
+          ./build_release.sh
+          zip -r ${{ steps.get_tag.outputs.tag }}.zip directory_name
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+      - name: Upload Release Asset
+        id: upload-release-asset 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./${{ steps.get_tag.outputs.tag }}.zip
+          asset_name: ${{ steps.get_tag.outputs.tag }}.zip
+          asset_content_type: application/zip

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -9,12 +9,28 @@ Then run it as a simple CLI tool. With the following flags:
 
 **-t,  --translations** is the flag to list the translation languages which you want your resource file to be translated to. 
 
-**-t, --file** The path to your resource file
+**-f, --file** The path to your resource file
 
 **-l, --language** The language of your current resource file.
 
 **-p, --path** The path where your Resx will be created. The default path is in your documents folder.
 
+**-k, --key** Google translation API Key
+
+**-e, --existing** If flag is present, then it will look for an existing translation and only update new occurances.
+
 ### Example 
 -t hi,pt,fr,ru -f  "C:\Users\john\Desktop\Resources.resx"  -p  "C:\Users\john\Desktop"
 
+## Build for Global Use
+
+Running `./build_release.sh` locally which produces a directory with a `lib` folder (the built project) and a `bin` folder (a convenience script which calls `mono` to run the program. This can be installed globally to be able to run this program anywhere.
+
+```(sh)
+./build_release.sh
+cp Release/bin/resx_translator /usr/local/bin/
+cp -R Release/lib/ /usr/local/lib/
+```
+
+### Example
+`./resx_translator -t hi,pt,fr,ru -f "../Strings/Resources.resx"  -p  "../Strings" -k secret_key.json`

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -33,4 +33,4 @@ cp -R Release/lib/ /usr/local/lib/
 ```
 
 ### Example
-`./resx_translator -t hi,pt,fr,ru -f "../Strings/Resources.resx"  -p  "../Strings" -k secret_key.json`
+`resx_translator -t hi,pt,fr,ru -f "../Strings/Resources.resx"  -p  "../Strings" -k secret_key.json`

--- a/ResXTranslator/App.config
+++ b/ResXTranslator/App.config
@@ -6,10 +6,6 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.1.3" newVersion="4.1.1.3" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="Google.Apis" publicKeyToken="4b01fa6e34db77ab" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.55.0.0" newVersion="1.55.0.0" />
       </dependentAssembly>

--- a/ResXTranslator/Parsers/CLIOptions.cs
+++ b/ResXTranslator/Parsers/CLIOptions.cs
@@ -33,5 +33,8 @@ namespace ResXTranslator.Parsers
 
         [Option('k', "key", HelpText = "Google translation API Key.")]
         public string APIKeyPath { get; set; }
+
+        [Option('e', "existing", HelpText = "If flag is present, then it will look for an existing translation and only update new occurances.", Max = 0)]
+        public bool UseExistingTranslation { get; set; }
     }
 }

--- a/ResXTranslator/Parsers/Parser.cs
+++ b/ResXTranslator/Parsers/Parser.cs
@@ -24,18 +24,28 @@ namespace ResXTranslator.Parsers
                 {
                     try
                     {
-                        if (!File.Exists(o.FilePath))
+                        if (!File.Exists(Path.Combine(Environment.CurrentDirectory, o.FilePath)))
                         {
                             Console.WriteLine("The file path precised for this resource doesn't exist.");
                             Environment.Exit(-1);
                         }
-                        if (string.IsNullOrEmpty(o.OutPutPath) || !Directory.Exists(o.OutPutPath))
+
+                        if (string.IsNullOrEmpty(o.OutPutPath) || !Directory.Exists(Path.Combine(Environment.CurrentDirectory, o.OutPutPath)))
                         {
                             o.OutPutPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
                             Console.WriteLine("The output directory precised doesn't exist. Translations will be created in your documents directory.");
                         }
+                        else
+                        {
+                            o.OutPutPath = Path.Combine(Environment.CurrentDirectory, o.OutPutPath);
+                        }
 
-                        func(o);
+                        if (!string.IsNullOrEmpty(o.APIKeyPath) || Directory.Exists(Path.Combine(Environment.CurrentDirectory, o.APIKeyPath)))
+                        {
+                            o.APIKeyPath = Path.Combine(Environment.CurrentDirectory, o.APIKeyPath);
+                        }
+
+                            func(o);
                     }
                     catch (Exception e)
                     {

--- a/ResXTranslator/Parsers/Parser.cs
+++ b/ResXTranslator/Parsers/Parser.cs
@@ -2,13 +2,13 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Text;
+using System.Threading.Tasks;
 
 namespace ResXTranslator.Parsers
 {
     public static class CLIParser
     {
-        public static void Parse(List<string> args, Action<CLIOptions> func)
+        public static void Parse(List<string> args, Func<CLIOptions, Task> func)
         {
             var options = Parser.Default.ParseArguments<CLIOptions>(args)
                 .WithNotParsed(err =>
@@ -45,7 +45,7 @@ namespace ResXTranslator.Parsers
                             o.APIKeyPath = Path.Combine(Environment.CurrentDirectory, o.APIKeyPath);
                         }
 
-                            func(o);
+                        func(o).GetAwaiter().GetResult();
                     }
                     catch (Exception e)
                     {

--- a/ResXTranslator/Program.cs
+++ b/ResXTranslator/Program.cs
@@ -29,27 +29,29 @@ namespace ResxTranslator
             var resources = resxHandler.Read(options.FilePath);
             foreach (var lge in options.TranslationLanguages)
             {
+                var resourcesCopy = resources.Select((o) => o).ToList();
                 var outputFileName = $"{Path.GetFileNameWithoutExtension(options.FilePath)}.{lge}{Path.GetExtension(options.FilePath)}";
                 var outputFile = Path.Combine(options.OutPutPath, outputFileName);
                 var dic = new Dictionary<string, string>();
                 if (options.UseExistingTranslation && File.Exists(outputFile))
                 {
                     var existingValues = resxHandler.Read(outputFile);
-                    foreach (var resource in resources.ToList())
+                    foreach (var resource in resourcesCopy.ToList())
                     {
                         var key = resource.Key;
                         if (existingValues.ContainsKey(key))
                         {
                             dic.Add(key, existingValues[key]);
-                            resources.Remove(resource.Key);
+                            resourcesCopy.Remove(resource);
                         }
                     }
                 }
-
-                var translationResults = await translator.TranslateAsync(resources.Values, lge, options.ResourceLanguage).ConfigureAwait(false);
+                var keys = resourcesCopy.Select((o) => o.Key).ToList();
+                var values = resourcesCopy.Select((o) => o.Value).ToList();
+                var translationResults = await translator.TranslateAsync(values, lge, options.ResourceLanguage).ConfigureAwait(false);
                 for (int i = 0; i < translationResults.Count(); i++)
                 {
-                    var key = resources.Keys.ElementAt(i);
+                    var key = keys.ElementAt(i);
                     dic.Add(key, translationResults.ElementAt(i));
                 }
                 resxHandler.Create(dic, outputFileName, options.OutPutPath);

--- a/ResXTranslator/Program.cs
+++ b/ResXTranslator/Program.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace ResxTranslator
 {
@@ -12,10 +13,11 @@ namespace ResxTranslator
     {
         public static void Main(string[] args)
         {
-            CLIParser.Parse(new List<string>(args), Run);
+            Func<CLIOptions, Task> RunAction = async (options) => await Run(options);
+            CLIParser.Parse(new List<string>(args), RunAction);
         }
 
-        static async void Run(CLIOptions options)
+        static async Task Run(CLIOptions options)
         {
             IResxHandler resxHandler = new SimpleResxHandler();
             ITranslator translator;
@@ -44,7 +46,7 @@ namespace ResxTranslator
                     }
                 }
 
-                var translationResults = await translator.TranslateAsync(resources.Values, lge, options.ResourceLanguage);
+                var translationResults = await translator.TranslateAsync(resources.Values, lge, options.ResourceLanguage).ConfigureAwait(false);
                 for (int i = 0; i < translationResults.Count(); i++)
                 {
                     var key = resources.Keys.ElementAt(i);

--- a/ResXTranslator/Program.cs
+++ b/ResXTranslator/Program.cs
@@ -2,14 +2,9 @@ using ResXTranslator.Parsers;
 using ResXTranslator.ResxHandler;
 using ResXTranslator.TranslationServices;
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Resources;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace ResxTranslator
 {
@@ -30,18 +25,33 @@ namespace ResxTranslator
                 translator = new GoogleTranslation(options.APIKeyPath);
 
             var resources = resxHandler.Read(options.FilePath);
-            var words = resources.Select(kv => kv.Value);
             foreach (var lge in options.TranslationLanguages)
             {
-                var res = await translator.TranslateAsync(new List<string>(words), lge);
+                var outputFileName = $"{Path.GetFileNameWithoutExtension(options.FilePath)}.{lge}{Path.GetExtension(options.FilePath)}";
+                var outputFile = Path.Combine(options.OutPutPath, outputFileName);
                 var dic = new Dictionary<string, string>();
-                var outputFile = $"{Path.GetFileNameWithoutExtension(options.FilePath)}.{lge}{Path.GetExtension(options.FilePath)}";
-                for (int i = 0; i < res.Count(); i++)
+                if (options.UseExistingTranslation && File.Exists(outputFile))
                 {
-                    dic.Add(resources.Keys.ElementAt(i), res.ElementAt(i));
+                    var existingValues = resxHandler.Read(outputFile);
+                    foreach (var resource in resources.ToList())
+                    {
+                        var key = resource.Key;
+                        if (existingValues.ContainsKey(key))
+                        {
+                            dic.Add(key, existingValues[key]);
+                            resources.Remove(resource.Key);
+                        }
+                    }
                 }
-                resxHandler.Create(dic, outputFile, options.OutPutPath);
-                Console.WriteLine($"Translations finished and file created: ${outputFile}");
+
+                var translationResults = await translator.TranslateAsync(resources.Values, lge, options.ResourceLanguage);
+                for (int i = 0; i < translationResults.Count(); i++)
+                {
+                    var key = resources.Keys.ElementAt(i);
+                    dic.Add(key, translationResults.ElementAt(i));
+                }
+                resxHandler.Create(dic, outputFileName, options.OutPutPath);
+                Console.WriteLine($"Translations finished and file created: ${outputFileName}");
             }
         }
     }

--- a/ResXTranslator/ResXTranslator.csproj
+++ b/ResXTranslator/ResXTranslator.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -8,12 +8,11 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>ResxTranslator</RootNamespace>
     <AssemblyName>ResxTranslator</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -23,13 +22,15 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(RunConfiguration)' == 'LocalFiles' ">
+    <StartAction>Project</StartAction>
+    <StartArguments>-f ../../../AppTests/Resources.resx -t es -l en -p ../../../AppTests -k ../../../client_secrets.json</StartArguments>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="CommandLine, Version=2.8.0.0, Culture=neutral, PublicKeyToken=5a870481e358d379, processorArchitecture=MSIL">

--- a/ResXTranslator/TranslationServices/GoogleTranslation.cs
+++ b/ResXTranslator/TranslationServices/GoogleTranslation.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.IO;
 using System;
+using System.Threading;
 
 namespace ResXTranslator.TranslationServices
 {
@@ -38,7 +39,9 @@ namespace ResXTranslator.TranslationServices
             }
             return 0;
         }
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
         public async Task<string> TranslateAsync(string text, string language, string sourceLanguage = null)
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
         {
             string translation = string.Empty;
             try
@@ -52,9 +55,10 @@ namespace ResXTranslator.TranslationServices
                     Console.WriteLine("The language code you entered could not be handled.");
                     Environment.Exit(-1);
                 }
-                var result = await _client.TranslateTextAsync(text, langCode.First(), sourceLanguage);
+                var result = _client.TranslateText(text, langCode.First(), sourceLanguage);
                 Console.WriteLine($"Translated {text} from {result.DetectedSourceLanguage} to {langCode.First()}");
                 translation = result.TranslatedText;
+                Thread.Sleep(1000);
             }
             catch (Exception e)
             {

--- a/ResXTranslator/TranslationServices/GoogleTranslation.cs
+++ b/ResXTranslator/TranslationServices/GoogleTranslation.cs
@@ -39,9 +39,7 @@ namespace ResXTranslator.TranslationServices
             }
             return 0;
         }
-#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
         public async Task<string> TranslateAsync(string text, string language, string sourceLanguage = null)
-#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
         {
             string translation = string.Empty;
             try
@@ -55,10 +53,10 @@ namespace ResXTranslator.TranslationServices
                     Console.WriteLine("The language code you entered could not be handled.");
                     Environment.Exit(-1);
                 }
-                var result = _client.TranslateText(text, langCode.First(), sourceLanguage);
+                var result = await _client.TranslateTextAsync(text, langCode.First(), sourceLanguage);
                 Console.WriteLine($"Translated {text} from {result.DetectedSourceLanguage} to {langCode.First()}");
                 translation = result.TranslatedText;
-                Thread.Sleep(1000);
+                await Task.Delay(1000).ConfigureAwait(false);
             }
             catch (Exception e)
             {

--- a/build_release.sh
+++ b/build_release.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+nuget restore
+# Options Debug|Release
+CONFIGURATION=Release
+msbuild ResxTranslator/ResxTranslator.csproj /property:Configuration=$CONFIGURATION
+rm -rf $CONFIGURATION
+
+mkdir -p $CONFIGURATION/lib
+mkdir -p $CONFIGURATION/bin
+mv ResxTranslator/bin/$CONFIGURATION $CONFIGURATION/lib/ResxTranslator
+echo "#!/bin/sh
+SCRIPT_DIR=\$( cd -- \"\$( dirname -- \"\${BASH_SOURCE[0]}\" )\" &> /dev/null && pwd )
+exec mono \$SCRIPT_DIR/../lib/ResxTranslator/ResxTranslator.exe \"\$@\"" >> $CONFIGURATION/bin/resx_translator
+chmod +x $CONFIGURATION/bin/resx_translator


### PR DESCRIPTION
I added a flag `-e`, which reads an existing translated file. The idea here is you wouldn't use Google API to translate items you have already translated.

I updated GoogleTranslator implementation _slightly_. When I was running it locally, the `await` task was never completed. So I just called the synchronous method (which is what it was essentially doing anyways). I also added a wait because I was hitting 403 errors.

Finally, I added a way to use this globally. Aimed for more macOS and Linux users, this allows the program to be built for a global command line (assuming the user has `mono` installed). The main changes here, besides the script, included prepending the path to the input and output file/directory. 